### PR TITLE
Add CMD to remove runtime option toml2json

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,3 +6,5 @@ RUN go get github.com/creack/toml2json
 FROM alpine:3.6
 MAINTAINER Jason Crowe <jcrowe@mozilla.com>
 COPY --from=build-toml2json /go/bin/toml2json /usr/local/bin/
+
+CMD [ "toml2json" ]

--- a/README.md
+++ b/README.md
@@ -5,14 +5,14 @@ This is a small docker container (6.42MB) containing toml2json.
 Run it like:
 
 ```bash
-echo 'arena = "core"' | docker run -i nubis-toml2json toml2json
+echo 'arena = "core"' | docker run -i nubis-toml2json
 ```
 
 Or in a script like:
 
 ```bash
-ARENA=$(cat ${TERRAFORM_PATH}/terraform.tfvars \
-    | docker run -i nubis-toml2json toml2json \
+ARENA=$(docker run -i nubis-toml2json \
+    < ${TERRAFORM_PATH}/terraform.tfvars \
     | docker run -i nubis-jq jq --raw-output .arena)
 echo "ARENA: ${ARENA}"
 ```


### PR DESCRIPTION
toml2json has no command line options, hence there is no need to add the
extra bit every time it is invoked